### PR TITLE
modified to responsive design on user page

### DIFF
--- a/Components/Cart/Cart.tsx
+++ b/Components/Cart/Cart.tsx
@@ -51,7 +51,7 @@ export const Cart = () => {
 			<div className="fixed inset-0 z-40 w-full">
 				{/* cart section */}
 				<div
-					className={`absolute h-full min-h-screen w-1/3 bg-[#F1EEEE] px-8 py-5 shadow-2xl duration-500 ease-in-out ${
+					className={`absolute h-full min-h-screen w-2/3 bg-[#F1EEEE] px-8 py-5 shadow-2xl duration-500 ease-in-out md:w-1/3 ${
 						!cartVisible ? '-right-full' : 'right-0'
 					}`}
 				>

--- a/Components/UserItems/UserItem/UserItem.tsx
+++ b/Components/UserItems/UserItem/UserItem.tsx
@@ -24,7 +24,7 @@ export function UserItem({ item }: Props) {
 		<>
 			<button onClick={handleModalOpen}>
 				<div className="h-full rounded-lg shadow-lg hover:cursor-pointer ">
-					<section className="h-64  rounded-t-md">
+					<section className="h-28 rounded-t-md sm:h-52  lg:h-64">
 						<CldImage
 							className="h-full w-full  rounded-t-md object-cover "
 							alt="item-image"
@@ -33,10 +33,12 @@ export function UserItem({ item }: Props) {
 							height={300}
 						/>
 					</section>
-					<section className="flex h-28 flex-col justify-between p-5 ">
+					<section className="flex h-28 flex-col justify-between py-4 lg:p-5 ">
 						<div className="flex h-full flex-col justify-between">
-							<div className="text-md px-3">{item.title}</div>
-							<div className="text-md px-3 text-xl font-bold text-gray-600">
+							<div className="md:text-md px-3 text-xs lg:text-lg">
+								{item.title}
+							</div>
+							<div className="sm:text-md px-3 text-sm font-bold text-gray-600 lg:text-xl">
 								$ {item.price}
 							</div>
 						</div>

--- a/Components/UserItems/UserItems.tsx
+++ b/Components/UserItems/UserItems.tsx
@@ -36,9 +36,9 @@ export function UserItems() {
 	return (
 		<>
 			{cartVisible && <Cart />}
-			<div className="no-scrollbar h-full w-full overflow-y-scroll px-20 pt-20">
-				<div className="rounded-xl bg-white px-16 py-10 shadow-lg">
-					<div className="grid gap-5 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 ">
+			<div className="no-scrollbar h-full w-full overflow-y-scroll pt-20 md:px-20">
+				<div className="rounded-xl bg-white px-5 py-10 shadow-lg md:px-16">
+					<div className="grid grid-cols-2 gap-5  md:grid-cols-3 lg:grid-cols-4 ">
 						{itemsList?.items?.map((data: ItemsType, id: number) => (
 							<UserItem key={id} item={data} />
 						))}

--- a/Components/UserModal/UserModal.tsx
+++ b/Components/UserModal/UserModal.tsx
@@ -101,7 +101,7 @@ export function UserModal() {
 							leaveFrom="opacity-100"
 							leaveTo="opacity-0"
 						>
-							<Dialog.Panel className="w-1/3 transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+							<Dialog.Panel className="w-3/4 transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all sm:w-1/3">
 								{loading ? (
 									<div>
 										Loading...
@@ -111,7 +111,7 @@ export function UserModal() {
 									<>
 										<div className="flex flex-col items-center">
 											{/* Image size */}
-											<div className="h-80 w-96">
+											<div className="h-32 w-full md:h-40 lg:h-80 lg:w-96 ">
 												<CldImage
 													alt="item-image"
 													className="h-full w-full rounded-2xl object-cover"
@@ -121,17 +121,17 @@ export function UserModal() {
 												/>
 											</div>
 
-											<div className="mt-5 flex w-fit flex-col items-center px-5">
+											<div className="my-3 flex w-fit flex-col items-center px-5 md:mt-5">
 												<p className="text-xl font-bold leading-6 text-gray-900">{`${item.title}`}</p>
 												<p className="text-lg">${`${item.price}`}</p>
 											</div>
 
-											<section className="m-5 flex w-full flex-col ">
+											<section className="flex w-full flex-col ">
 												<div className="my-4 flex w-full max-w-lg flex-row flex-wrap justify-start px-4">
 													{allergies?.map((allergy: string, idx: number) => (
 														<div
 															key={idx}
-															className="mr-2 flex w-fit flex-row items-center rounded-full border border-[#FF7474] bg-white px-4 py-1 text-[#FF7474]"
+															className="mr-2 flex w-fit flex-row items-center rounded-full border border-[#FF7474] bg-white px-4 py-1 text-sm text-[#FF7474]"
 														>
 															{allergy}
 														</div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,10 +2,11 @@ import type { Config } from 'tailwindcss'
 
 const config: Config = {
 	content: [
-		// './pages/**/*.{js,ts,jsx,tsx,mdx}',/
+		// './pages/**/*.{js,ts,jsx,tsx,mdx}',//
 		'./components/**/*.{js,ts,jsx,tsx,mdx}',
 		'./components/**/**/*.{js,ts,jsx,tsx,mdx}',
-		'./app/**/**/*.{js,ts,jsx,tsx,mdx}'
+		'./app/**/**/*.{js,ts,jsx,tsx,mdx}',
+		'./app/**/*.{js,ts,jsx,tsx,mdx}'
 	],
 	theme: {
 		extend: {
@@ -14,6 +15,11 @@ const config: Config = {
 				'gradient-conic':
 					'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))'
 			}
+		},
+		screens: {
+			sm: '640px',
+			md: '768px',
+			lg: '1024px'
 		}
 	},
 	plugins: []


### PR DESCRIPTION
## Proposed Changes
#### Code changes
- Modified responsive design on user page

#### Issues affected
- None

## Additional Info
- Nothing

## Screenshots and/or video
### Item List page 

- Tablet
<img width="758" alt="スクリーン ショット 2023-10-10 に 22 09 00 午後" src="https://github.com/ryoosukesaito/Meal-ordering-app/assets/104223502/b983f7cd-a3a7-4902-bd3c-063202084eae">

<br/>
<br/>

- Smartphone
<img width="314" alt="スクリーン ショット 2023-10-10 に 22 09 11 午後" src="https://github.com/ryoosukesaito/Meal-ordering-app/assets/104223502/fbefae48-54c8-44b6-9c1b-de2efe058482">

### Modal

- Tablet
<img width="761" alt="スクリーン ショット 2023-10-10 に 22 09 25 午後" src="https://github.com/ryoosukesaito/Meal-ordering-app/assets/104223502/1a9f565a-2228-4d9c-88d1-f2c558749bdf">

<br/>
<br/>

- Smartphone
<img width="313" alt="スクリーン ショット 2023-10-10 に 22 09 34 午後" src="https://github.com/ryoosukesaito/Meal-ordering-app/assets/104223502/d191fd3e-75ef-4f00-80a2-c85f4bbf2ccb">

### Cart
- Tablet
<img width="757" alt="スクリーン ショット 2023-10-10 に 22 09 50 午後" src="https://github.com/ryoosukesaito/Meal-ordering-app/assets/104223502/7de55cbb-e090-4f33-b87f-7512141bad24">

- Smartphone
<img width="309" alt="スクリーン ショット 2023-10-10 に 22 09 59 午後" src="https://github.com/ryoosukesaito/Meal-ordering-app/assets/104223502/80cf8a6b-ce0d-48aa-8189-5d5113811415">



## Testing Plan
Front-end
-Check perfect styles-

- [x] Laptop
- [x] Tablet
- [x] Smartphone

Back-end
-Check response from Database-

- [x] No error

## Checklist
#### Basics

- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)